### PR TITLE
Make the package PHP8.2 ready

### DIFF
--- a/src/Cli/Helpers/Job.php
+++ b/src/Cli/Helpers/Job.php
@@ -49,7 +49,8 @@ class Job
     protected $message;
     protected $function;
     protected $debug;
-
+    protected $arguments;
+    
     public function __construct($message, $function, $arguments = array(), $debug = false)
     {
         $this->message = $message;


### PR DESCRIPTION
The Package thows an error on PHP8.2 this fixes the deprecation warning.

`Creation of dynamic property Cli\Helpers\Job::$arguments is deprecated in .....`